### PR TITLE
Use signature version 4 in eu-central-1

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -19,10 +19,14 @@ type Credentials struct {
 }
 
 // Sign signs a request bound for AWS. It automatically chooses the best
-// authentication scheme based on the service the request is going to.
+// authentication scheme based on the service and region the request is going
+// to.
 func Sign(req *http.Request, cred ...Credentials) *http.Request {
-	service, _ := serviceAndRegion(req.URL.Host)
+	service, region := serviceAndRegion(req.URL.Host)
 	sigVersion := awsSignVersion[service]
+	if regionSigVersion, present := awsRegionSignVersion[region]; present && sigVersion < regionSigVersion {
+		sigVersion = regionSigVersion
+	}
 
 	switch sigVersion {
 	case 2:
@@ -225,6 +229,10 @@ var (
 		"route53":              3,
 		"elasticloadbalancing": 4,
 		"email":                3,
+	}
+
+	awsRegionSignVersion = map[string]int{
+		"eu-central-1": 4,
 	}
 
 	signMutex sync.Mutex

--- a/awsauth_test.go
+++ b/awsauth_test.go
@@ -211,6 +211,18 @@ func TestSign(t *testing.T) {
 			So(signedReq.Header.Get("Authorization"), ShouldContainSubstring, ", Signature=")
 		}
 	})
+
+	Convey("Requests to regions requiring Version 4 should be signed accordingly", t, func() {
+		reqs := []*http.Request{
+			newRequest("GET", "https://ec2.eu-central-1.amazonaws.com", url.Values{}), // Normally V2
+			newRequest("GET", "https://email.eu-central-1.amazonaws.com", url.Values{}), // Normally V3
+			newRequest("GET", "https://s3.eu-central-1.amazonaws.com", url.Values{}), // Normally V4
+		}
+		for _, req := range reqs {
+			signedReq := Sign(req)
+			So(signedReq.Header.Get("Authorization"), ShouldContainSubstring, ", Signature=")
+		}
+	})
 }
 
 func TestExpiration(t *testing.T) {


### PR DESCRIPTION
Per https://aws.amazon.com/blogs/aws/aws-region-germany/, Version 4 is the
minimum required signature version for all services in eu-central-1.

> For Developers – Signature Version 4 Support
> This new Region supports only Signature Version 4. If you have built applications with the AWS SDKs or the AWS Command Line Interface (CLI) and your API calls are being rejected, you should update to the newest SDK and CLI. To learn more, visit Using the AWS SDKs and Explorers.