### PR TITLE
Double-encoding of certain characters in path fragments for non-S3 URLs

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -78,9 +78,9 @@ func TestCommonFunctions(t *testing.T) {
 	})
 
 	Convey("URI components should be properly encoded", t, func() {
-		So(normuri("/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"), ShouldEqual, "/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
-		So(normuri("/ /foo"), ShouldEqual, "/%20/foo")
-		So(normuri("/(foo)"), ShouldEqual, "/%28foo%29")
+		So(normuri("/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", false), ShouldEqual, "/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
+		So(normuri("/ /foo", false), ShouldEqual, "/%20/foo")
+		So(normuri("/(foo)", false), ShouldEqual, "/%2528foo%2529")
 	})
 
 	Convey("URI query strings should be properly encoded", t, func() {

--- a/sign4.go
+++ b/sign4.go
@@ -45,8 +45,12 @@ func hashedCanonicalRequestV4(request *http.Request, meta *metadata) string {
 		}
 		headersToSign += key + ":" + value + "\n"
 	}
+	var isS3 bool
+	if strings.Contains(request.Host, "s3.amazonaws.com") {
+		isS3 = true
+	}
 	meta.signedHeaders = concat(";", sortedHeaderKeys...)
-	canonicalRequest := concat("\n", request.Method, normuri(request.URL.Path), normquery(request.URL.Query()), headersToSign, meta.signedHeaders, payloadHash)
+	canonicalRequest := concat("\n", request.Method, normuri(request.URL.Path, isS3), normquery(request.URL.Query()), headersToSign, meta.signedHeaders, payloadHash)
 
 	return hashSHA256([]byte(canonicalRequest))
 }


### PR DESCRIPTION
This is a first-crack at resolving #28, which is particularly troubling when trying to do multi-index or multi-type searching on AWS Elasticsearch Service.
## Please Note

I'm not as familiar with the AWS V4 signing process as I'd like to be. For that reason, this will probably take some scrupulous review by the authors/maintainers. I'm happy to make any alterations, though, so please feel free to ask!

This was altered for our application of go-aws-auth for the Elasticsearch service, and we do not use it for any other service, so if anyone is using other services then testing this signing with your services would be much appreciated.
