### PR TITLE
Support Custom API endpoints

### DIFF
--- a/awsauth_test.go
+++ b/awsauth_test.go
@@ -181,6 +181,17 @@ func TestSign(t *testing.T) {
 		}
 	})
 
+	Convey("Requests to Custom URLs should be signed accordingly", t, func() {
+		reqs := []*http.Request{
+			newRequest("POST", "https://customurl.foobarbaz.com/", url.Values{}),
+			newRequest("GET", "https://customurl.foobarbaz.com", url.Values{}),
+		}
+		for _, request := range reqs {
+			signedReq := SignCustomApiRequest(request, "us-east-1")
+			So(signedReq.Header.Get("Authorization"), ShouldContainSubstring, ", Signature=")
+		}
+	})
+
 	var keys Credentials
 	keys = newKeys()
 	Convey("Requests to services using existing credentials Version 2 should be signed accordingly", t, func() {
@@ -213,6 +224,17 @@ func TestSign(t *testing.T) {
 		}
 		for _, request := range reqs {
 			signedReq := Sign(request, keys)
+			So(signedReq.Header.Get("Authorization"), ShouldContainSubstring, ", Signature=")
+		}
+	})
+
+	Convey("Requests to Custom URLs using existing credentials should be signed accordingly", t, func() {
+		reqs := []*http.Request{
+			newRequest("POST", "https://customurl.foobarbaz.com/", url.Values{}),
+			newRequest("GET", "https://customurl.foobarbaz.com", url.Values{}),
+		}
+		for _, request := range reqs {
+			signedReq := SignCustomApiRequest(request, "us-east-1", keys)
 			So(signedReq.Header.Get("Authorization"), ShouldContainSubstring, ", Signature=")
 		}
 	})

--- a/common_test.go
+++ b/common_test.go
@@ -36,6 +36,10 @@ func TestCommonFunctions(t *testing.T) {
 		service, region = serviceAndRegion("s3-external-1.amazonaws.com")
 		So(service, ShouldEqual, "s3")
 		So(region, ShouldEqual, "us-east-1")
+
+		service, region = serviceAndRegion("foo123bar.execute-api.us-east-1.amazonaws.com")
+		So(service, ShouldEqual, "execute-api")
+		So(region, ShouldEqual, "us-east-1")
 	})
 
 	Convey("MD5 hashes should be properly computed and base-64 encoded", t, func() {

--- a/sign4.go
+++ b/sign4.go
@@ -57,7 +57,9 @@ func stringToSignV4(request *http.Request, hashedCanonReq string, meta *metadata
 	requestTs := request.Header.Get("X-Amz-Date")
 
 	meta.algorithm = "AWS4-HMAC-SHA256"
-	meta.service, meta.region = serviceAndRegion(request.Host)
+	if meta.region == "" || meta.service == "" {
+		meta.service, meta.region = serviceAndRegion(request.Host)
+	}
 	meta.date = tsDateV4(requestTs)
 	meta.credentialScope = concat("/", meta.date, meta.region, meta.service, "aws4_request")
 

--- a/sign4_test.go
+++ b/sign4_test.go
@@ -93,6 +93,16 @@ func TestVersion4SigningTasks(t *testing.T) {
 			So(stringToSign, ShouldEqual, expectingV4["StringToSign"])
 		})
 
+		Convey("(Task 2) The string to sign should be build correctly with custom meta", func() {
+			customMeta := new(metadata)
+			customMeta.region = "foo"
+			customMeta.service = "bar"
+			hashedCanonReq := hashedCanonicalRequestV4(request, customMeta)
+			stringToSign := stringToSignV4(request, hashedCanonReq, customMeta)
+
+			So(stringToSign, ShouldEqual, expectingV4["CustomStringToSign"])
+		})
+
 		Convey("(Task 3) The version 4 signed signature should be correct", func() {
 			hashedCanonReq := hashedCanonicalRequestV4(request, meta)
 			stringToSign := stringToSignV4(request, hashedCanonReq, meta)
@@ -204,10 +214,11 @@ var (
 	}
 
 	expectingV4 = map[string]string{
-		"CanonicalHash": "41c56ed0df12052f7c10407a809e64cd61a4b0471956cdea28d6d1bb904f5d92",
-		"StringToSign":  "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/iam/aws4_request\n41c56ed0df12052f7c10407a809e64cd61a4b0471956cdea28d6d1bb904f5d92",
-		"SignatureV4":   "08292a4b86aae1a6f80f1988182a33cbf73ccc70c5da505303e355a67cc64cb4",
-		"AuthHeader":    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=",
+		"CanonicalHash":      "41c56ed0df12052f7c10407a809e64cd61a4b0471956cdea28d6d1bb904f5d92",
+		"StringToSign":       "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/us-east-1/iam/aws4_request\n41c56ed0df12052f7c10407a809e64cd61a4b0471956cdea28d6d1bb904f5d92",
+		"CustomStringToSign": "AWS4-HMAC-SHA256\n20110909T233600Z\n20110909/foo/bar/aws4_request\n41c56ed0df12052f7c10407a809e64cd61a4b0471956cdea28d6d1bb904f5d92",
+		"SignatureV4":        "08292a4b86aae1a6f80f1988182a33cbf73ccc70c5da505303e355a67cc64cb4",
+		"AuthHeader":         "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=",
 	}
 
 	requestValuesV4 = &url.Values{


### PR DESCRIPTION
This addresses #26 
- Add function to support signing AWS requests with custom URLs
- Support AWS credentials stored in Profile, rewrite ENV credential support slightly
- Support 'execute-api' for standard urls through Sign method based on code from @brianfaull
