### PR TITLE
Add Lambda Support

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -187,6 +187,7 @@ const (
 	envSecretKey       = "AWS_SECRET_KEY"
 	envSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 	envSecurityToken   = "AWS_SECURITY_TOKEN"
+	envSessionToken    = "AWS_SESSION_TOKEN"
 )
 
 var (

--- a/common.go
+++ b/common.go
@@ -78,6 +78,9 @@ func newKeys() (newCredentials Credentials) {
 	}
 
 	newCredentials.SecurityToken = os.Getenv(envSecurityToken)
+	if newCredentials.SecurityToken == "" {
+		newCredentials.SecurityToken = os.Getenv(envSessionToken)
+	}
 
 	// If there is no Access Key and you are on EC2, get the key from the role
 	if (newCredentials.AccessKeyID == "" || newCredentials.SecretAccessKey == "") && onEC2() {


### PR DESCRIPTION
Lambda uses temporary credentials stored in a different environment variable. This change adds this fallback check for the alternate key. This prevents the "Security token is invalid" errors that crop up with trying to use Lambda with other AWS services via the Go-SDK.

-Steve