### PR TITLE
Allow caller to explicitly provide region/service

### DIFF
--- a/sign4.go
+++ b/sign4.go
@@ -57,7 +57,13 @@ func stringToSignV4(request *http.Request, hashedCanonReq string, meta *metadata
 	requestTs := request.Header.Get("X-Amz-Date")
 
 	meta.algorithm = "AWS4-HMAC-SHA256"
-	meta.service, meta.region = serviceAndRegion(request.Host)
+	service, region := serviceAndRegion(request.Host)
+	if meta.service == "" {
+		meta.service = service
+	}
+	if meta.region == "" {
+		meta.region = region
+	}
 	meta.date = tsDateV4(requestTs)
 	meta.credentialScope = concat("/", meta.date, meta.region, meta.service, "aws4_request")
 


### PR DESCRIPTION
 * adds SignForRegion and Sign4ForRegion
 * leaves existing fn sigs alone for back-compat

Workaround for issue #40 